### PR TITLE
Avoid renaming tasks

### DIFF
--- a/main.py
+++ b/main.py
@@ -103,13 +103,9 @@ class TodoistMetadataManager:
 
     def reschedule_task(self, task, new_due_date, failures):
         """Reschedule a single task to a specific date"""
-        prefix = "🔄" if failures >= 3 else ""
-        suffix = f" (Failed {failures}x)" if failures > 1 else ""
-
         self.api.update_task(
             task_id=task.id,
             due_date=new_due_date.date() if hasattr(new_due_date, 'date') else new_due_date,
-            content=f"{prefix}{task.content.replace('🔄', '').split(' (Failed')[0]}{suffix}"
         )
 
         print(f"Rescheduled: {task.content} → {new_due_date.strftime('%Y-%m-%d')} (failure #{failures})")


### PR DESCRIPTION
When renaming the tasks to include the number of failures any recurring scheduling information that may have been in the task is also lost. I'm not sure if setting the due date will also do this but I also don't need a constant reminder of failure in the title.